### PR TITLE
Surface lenses & getters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,3 +45,33 @@ libraryDependencies ++= Seq(
   "com.github.julien-truffaut" %%  "monocle-core"  % monocleVersion,
   "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion,
   "com.github.julien-truffaut" %%  "monocle-law"   % monocleVersion % "test")
+
+// Sonatype publishing conf.
+import xerial.sbt.Sonatype._
+
+publishTo := sonatypePublishTo.value
+sonatypeProfileName := "org.hablapps"
+publishMavenStyle := true
+licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+sonatypeProjectHosting := Some(GitHubHosting("hablapps", "puretest", "juanmanuel.serrano@hablapps.com"))
+homepage := Some(url("https://github.com/hablapps/puretest"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/hablapps/puretest"),
+    "scm:git@github.com:hablapps/puretest.git"
+  )
+)
+developers := List(
+  Developer(id="jserranohidalgo",
+    name="Juan Manuel Serrano Hidalgo",
+    email="juanmanuel.serrano@hablapps.com",
+    url=url("http://www.hablapps.com")),
+  Developer(id="javierfs89",
+    name="Javier Fuentes Sánchez",
+    email="javier.fuentes@hablapps.com",
+    url=url("http://www.hablapps.com")),
+  Developer(id="jeslg",
+    name="Jesús López González",
+    email="jesus.lopez@hablapps.com",
+    url=url("http://www.hablapps.com"))
+)

--- a/build.sbt
+++ b/build.sbt
@@ -38,37 +38,10 @@ val monocleVersion = "1.5.0"
 
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.2.8",
-  "org.typelevel" %% "cats-core" % "1.1.0",
+  "org.typelevel" %% "cats-core" % "0.9.0",
   "org.scalactic" %% "scalactic" % "3.0.5",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "com.chuusai" %% "shapeless" % "2.3.2",
   "com.github.julien-truffaut" %%  "monocle-core"  % monocleVersion,
   "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion,
   "com.github.julien-truffaut" %%  "monocle-law"   % monocleVersion % "test")
-
-
-// Sonatype publishing conf.
-import xerial.sbt.Sonatype._
-
-publishTo := sonatypePublishTo.value
-sonatypeProfileName := "org.hablapps"
-publishMavenStyle := true
-licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
-sonatypeProjectHosting := Some(GitHubHosting("hablapps", "shapelens", "juanmanuel.serrano@hablapps.com"))
-homepage := Some(url("https://github.com/hablapps/shapelens"))
-scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/hablapps/shapelens"),
-    "scm:git@github.com:hablapps/shapelens.git"
-  )
-)
-developers := List(
-  Developer(id="jserranohidalgo",
-    name="Juan Manuel Serrano Hidalgo",
-    email="juanmanuel.serrano@hablapps.com",
-    url=url("http://www.hablapps.com")),
-  Developer(id="jeslg",
-    name="Jesús López González",
-    email="jesus.lopez@hablapps.com",
-    url=url("http://www.hablapps.com"))
-)

--- a/build.sbt
+++ b/build.sbt
@@ -1,31 +1,74 @@
 name := "shapelens"
+version := "0.1-SNAPSHOT"
 
 organization := "org.hablapps"
 
-scalaVersion := "2.12.6"
-
-addCompilerPlugin("io.tryp" % "splain" % "0.3.1" cross CrossVersion.patch)
+scalaVersion := "2.10.6"
+crossScalaVersions := Seq("2.12.6", "2.10.6")
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
+
+libraryDependencies += scalaVersion{
+    case v if v.startsWith("2.10") =>
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    case _ =>
+      compilerPlugin("io.tryp" % "splain" % "0.3.1" cross CrossVersion.patch)
+  }.value
 
 scalacOptions ++= Seq(
   "-Xlint",
   "-unchecked",
   "-deprecation",
   "-feature",
-  "-Ypartial-unification",
   "-language:postfixOps",
   "-language:implicitConversions",
   "-language:higherKinds")
+
+scalacOptions ++= scalaVersion{
+  case v if v.startsWith("2.12") =>
+    Seq("-Ypartial-unification")
+  case _ =>
+    Seq()
+}.value
+
+scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Xlint"))
+scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 
 val monocleVersion = "1.5.0"
 
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.2.8",
-  "org.scalactic" %% "scalactic" % "3.0.5", 
+  "org.typelevel" %% "cats-core" % "1.1.0",
+  "org.scalactic" %% "scalactic" % "3.0.5",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-  "com.chuusai" %% "shapeless" % "2.3.3",
+  "com.chuusai" %% "shapeless" % "2.3.2",
   "com.github.julien-truffaut" %%  "monocle-core"  % monocleVersion,
   "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion,
   "com.github.julien-truffaut" %%  "monocle-law"   % monocleVersion % "test")
 
+
+// Sonatype publishing conf.
+import xerial.sbt.Sonatype._
+
+publishTo := sonatypePublishTo.value
+sonatypeProfileName := "org.hablapps"
+publishMavenStyle := true
+licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+sonatypeProjectHosting := Some(GitHubHosting("hablapps", "shapelens", "juanmanuel.serrano@hablapps.com"))
+homepage := Some(url("https://github.com/hablapps/shapelens"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/hablapps/shapelens"),
+    "scm:git@github.com:hablapps/shapelens.git"
+  )
+)
+developers := List(
+  Developer(id="jserranohidalgo",
+    name="Juan Manuel Serrano Hidalgo",
+    email="juanmanuel.serrano@hablapps.com",
+    url=url("http://www.hablapps.com")),
+  Developer(id="jeslg",
+    name="Jesús López González",
+    email="jesus.lopez@hablapps.com",
+    url=url("http://www.hablapps.com"))
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,0 @@
-addSbtPlugin("com.jsuereth"   %  "sbt-pgp"               % "1.1.1")
-addSbtPlugin("org.xerial.sbt" %  "sbt-sonatype"          % "2.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.jsuereth"   %  "sbt-pgp"               % "1.1.1")
+addSbtPlugin("org.xerial.sbt" %  "sbt-sonatype"          % "2.3")

--- a/src/main/scala/DeepLens.scala
+++ b/src/main/scala/DeepLens.scala
@@ -1,27 +1,27 @@
-package org.hablapps.shapelens
+package shapelens
 
 import scalaz._
 import shapeless._
 import monocle.Lens
 
-trait Shapelens[S, Ctx <: HList] {
+trait DeepLens[S, Ctx <: HList] {
   type A
   val value: Lens[S, A]
 }
 
-object Shapelens {
+object DeepLens {
 
-  type Aux[S, Ctx <: HList, A2] = Shapelens[S, Ctx] { type A = A2 }
+  type Aux[S, Ctx <: HList, A2] = DeepLens[S, Ctx] { type A = A2 }
 
-  def apply[S, Ctx <: HList](implicit ln: Shapelens[S, Ctx]): Lens[S, ln.A] = 
+  def apply[S, Ctx <: HList](implicit ln: DeepLens[S, Ctx]): Lens[S, ln.A] =
     ln.value
 
   def apply[S, Ctx <: HList, A2](ln: Lens[S, A2]): Aux[S, Ctx, A2] =
-    new Shapelens[S, Ctx] { type A = A2; val value = ln }
+    new DeepLens[S, Ctx] { type A = A2; val value = ln }
 
   implicit def base[S]: Aux[S, HNil, S] =
     apply(Lens.id)
-  
+
   implicit def inductive[S, H, T <: HList, A, B](implicit
       hln: MkFieldLens.Aux[S, H, A],
       tln: Aux[A, T, B]): Aux[S, H :: T, B] =

--- a/src/main/scala/DeepLens.scala
+++ b/src/main/scala/DeepLens.scala
@@ -1,8 +1,8 @@
 package shapelens
 
-import scalaz._
-import shapeless._
-import monocle.Lens
+import scalaz._, Scalaz._
+import shapeless._, labelled._
+import _root_.monocle.Lens
 
 trait DeepLens[S, Ctx <: HList] {
   type A

--- a/src/main/scala/KleisliToStateT.scala
+++ b/src/main/scala/KleisliToStateT.scala
@@ -1,0 +1,19 @@
+package shapelens
+
+import cats._, cats.data._, cats.implicits._
+
+trait KleisliToStateT[P[_], E2, E1]{
+  val apply: Kleisli[P, E1, ?] ~> StateT[P, E2, ?]
+}
+
+object KleisliToStateT{
+
+  def apply[P[_], E2, E1](implicit S: KleisliToStateT[P, E2, E1]) = S
+
+  implicit def kleisliToStateT[P[_]: Applicative, E2, E1](implicit
+      G: SurfaceGetter[P, E2, E1]) = new KleisliToStateT[P, E2, E1]{
+    val apply = λ[Kleisli[P, E1,?] ~> StateT[P, E2,?]]{
+      from => StateT{ e2 => G.apply(from)(e2) map ((e2, _)) }
+    }
+  }
+}

--- a/src/main/scala/NatTrans.scala
+++ b/src/main/scala/NatTrans.scala
@@ -1,0 +1,48 @@
+package shapelens
+
+import cats.{~>, Id, Eval}
+import cats.data.{Reader => CReader, State}
+
+trait NatTrans[P[_], Q[_]]{
+  val nat: P ~> Q
+}
+
+object NatTrans{
+
+  implicit def SurfaceGetterNatTrans[E2, E1](implicit
+      S: SurfaceGetter[Id, E2, E1]) =
+    new NatTrans[CReader[E1,?], CReader[E2,?]]{
+      val nat = S.apply
+    }
+
+  implicit def SurfaceLensNatTrans[E2, E1](implicit
+      S: SurfaceLens[Eval, E2, E1]) =
+    new NatTrans[State[E1,?], State[E2,?]]{
+      val nat = S.apply
+    }
+
+  implicit def KleisliToStateTNatTrans[E1, E2](implicit
+      K: KleisliToStateT[Id, E2, E1]) =
+    new NatTrans[CReader[E1,?], State[E2,?]]{
+      val nat = λ[CReader[E1,?] ~> State[E2,?]]{
+        p => K.apply(p).transformF(cats.Eval.now)
+      }
+    }
+
+  implicit def IdToOptionNatTrans =
+    new NatTrans[cats.Id, Option]{
+      val nat = λ[cats.Id ~> Option](x => Option(x))
+    }
+}
+
+trait NatTransLPI{
+
+  implicit def composition[P[_], Q[_], R[_]](implicit
+      PQ: NatTrans[P,Q],
+      QR: NatTrans[Q,R]) =
+    new NatTrans[P, R]{
+      val nat: P ~> R = λ[P ~> R]{
+        p => QR.nat(PQ.nat(p))
+      }
+    }
+}

--- a/src/main/scala/SurfaceGetter.scala
+++ b/src/main/scala/SurfaceGetter.scala
@@ -1,0 +1,44 @@
+package shapelens
+
+import cats._, cats.data._
+
+import shapeless._, ops.hlist._
+
+trait SurfaceGetter[E2, E1]{
+  def apply[P[_]]: Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]
+}
+
+object SurfaceGetter extends SurfaceGetterImplicits{
+
+  trait Syntax{
+    implicit def readerView[P[_], E2, E1, T](
+        r: Kleisli[P, E1, T])(implicit
+        S: SurfaceGetter[E2, E1]): Kleisli[P, E2, T] =
+      S.apply(r)
+  }
+}
+
+trait SurfaceGetterImplicits extends SurfaceGetterLPI{
+
+  implicit def surfaceGetter_singleField[
+      E2, E1, LE2 <: HList](implicit
+      GE2: Generic.Aux[E2, LE2],
+      S: Selector[LE2, E1]) = new SurfaceGetter[E2, E1]{
+    def apply[P[_]] = λ[Kleisli[P, E1,?] ~> Kleisli[P, E2,?]]{
+      _.local(GE2.to _ andThen S.apply)
+    }
+  }
+}
+
+trait SurfaceGetterLPI{
+  implicit def surfaceGetter_multipleField[
+      E2, E1, LE2 <: HList, LE1 <: HList](implicit
+      GE2: Generic.Aux[E2, LE2],
+      GE1: Generic.Aux[E1, LE1],
+      S: SelectAll[LE2, LE1]) = new SurfaceGetter[E2, E1]{
+    def apply[P[_]] = λ[Kleisli[P, E1,?] ~> Kleisli[P, E2,?]]{
+      _.local(GE2.to _ andThen S.apply andThen GE1.from)
+    }
+  }
+}
+

--- a/src/main/scala/SurfaceGetter.scala
+++ b/src/main/scala/SurfaceGetter.scala
@@ -4,8 +4,8 @@ import cats._, cats.data._
 
 import shapeless._, ops.hlist._
 
-trait SurfaceGetter[E2, E1]{
-  def apply[P[_]]: Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]
+trait SurfaceGetter[P[_], E2, E1]{
+  val apply: Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]
 }
 
 object SurfaceGetter extends SurfaceGetterImplicits{
@@ -13,7 +13,7 @@ object SurfaceGetter extends SurfaceGetterImplicits{
   trait Syntax{
     implicit def readerView[P[_], E2, E1, T](
         r: Kleisli[P, E1, T])(implicit
-        S: SurfaceGetter[E2, E1]): Kleisli[P, E2, T] =
+        S: SurfaceGetter[P, E2, E1]): Kleisli[P, E2, T] =
       S.apply(r)
   }
 }
@@ -21,10 +21,10 @@ object SurfaceGetter extends SurfaceGetterImplicits{
 trait SurfaceGetterImplicits extends SurfaceGetterLPI{
 
   implicit def surfaceGetter_singleField[
-      E2, E1, LE2 <: HList](implicit
+      P[_], E2, E1, LE2 <: HList](implicit
       GE2: Generic.Aux[E2, LE2],
-      S: Selector[LE2, E1]) = new SurfaceGetter[E2, E1]{
-    def apply[P[_]] = λ[Kleisli[P, E1,?] ~> Kleisli[P, E2,?]]{
+      S: Selector[LE2, E1]) = new SurfaceGetter[P, E2, E1]{
+    val apply = λ[Kleisli[P, E1,?] ~> Kleisli[P, E2,?]]{
       _.local(GE2.to _ andThen S.apply)
     }
   }
@@ -32,11 +32,11 @@ trait SurfaceGetterImplicits extends SurfaceGetterLPI{
 
 trait SurfaceGetterLPI{
   implicit def surfaceGetter_multipleField[
-      E2, E1, LE2 <: HList, LE1 <: HList](implicit
+      P[_], E2, E1, LE2 <: HList, LE1 <: HList](implicit
       GE2: Generic.Aux[E2, LE2],
       GE1: Generic.Aux[E1, LE1],
-      S: SelectAll[LE2, LE1]) = new SurfaceGetter[E2, E1]{
-    def apply[P[_]] = λ[Kleisli[P, E1,?] ~> Kleisli[P, E2,?]]{
+      S: SelectAll[LE2, LE1]) = new SurfaceGetter[P, E2, E1]{
+    val apply = λ[Kleisli[P, E1,?] ~> Kleisli[P, E2,?]]{
       _.local(GE2.to _ andThen S.apply andThen GE1.from)
     }
   }

--- a/src/main/scala/SurfaceGetterK.scala
+++ b/src/main/scala/SurfaceGetterK.scala
@@ -1,0 +1,52 @@
+package shapelens
+
+import cats.~>, cats.data.Kleisli
+
+import shapeless._, ops.record._
+
+trait SurfaceGetterK[E2, E1, K]{
+  def apply[P[_]]: Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]
+}
+
+object SurfaceGetterK extends SurfaceGetterKImplicits{
+
+  trait Syntax{
+    implicit class SurfaceGetterKOps[P[_], E1, T](r: Kleisli[P, E1, T]){
+      def at[E2](k: Witness)(implicit R: SurfaceGetterK[E2, E1, k.T]) =
+        R.apply(r)
+
+      def at[K <: HList, E2](k: K)(implicit R: SurfaceGetterK[E2, E1, K]) =
+        R.apply(r)
+    }
+  }
+}
+
+trait SurfaceGetterKImplicits extends SurfaceGetterKImplicitsLPI{
+
+  def apply[E1, E2, K](implicit R: SurfaceGetterK[E1, E2, K]) = R
+
+  implicit def surfaceGetterK_singleField[
+      E2, E1, K, LE2 <: HList](implicit
+      GE2: LabelledGeneric.Aux[E2, LE2],
+      S: Selector.Aux[LE2, K, E1]) =
+    new SurfaceGetterK[E2, E1, K]{
+      def apply[P[_]] = λ[Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]]{
+        _.local((GE2.to _) andThen S.apply)
+      }
+    }
+}
+
+trait SurfaceGetterKImplicitsLPI{
+
+  implicit def surfaceGetterK_multipleField[
+      E2, E1, K <: HList, LE2 <: HList, LE1 <: HList](implicit
+      GE2: LabelledGeneric.Aux[E2, LE2],
+      GE1: Generic.Aux[E1, LE1],
+      S: SelectAll.Aux[LE2, K, LE1]) =
+    new SurfaceGetterK[E2, E1, K]{
+      def apply[P[_]] = λ[Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]]{
+        _.local((GE2.to _) andThen S.apply andThen GE1.from)
+      }
+    }
+}
+

--- a/src/main/scala/SurfaceGetterK.scala
+++ b/src/main/scala/SurfaceGetterK.scala
@@ -4,18 +4,18 @@ import cats.~>, cats.data.Kleisli
 
 import shapeless._, ops.record._
 
-trait SurfaceGetterK[E2, E1, K]{
-  def apply[P[_]]: Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]
+trait SurfaceGetterK[P[_], E2, E1, K]{
+  val apply: Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]
 }
 
 object SurfaceGetterK extends SurfaceGetterKImplicits{
 
   trait Syntax{
     implicit class SurfaceGetterKOps[P[_], E1, T](r: Kleisli[P, E1, T]){
-      def at[E2](k: Witness)(implicit R: SurfaceGetterK[E2, E1, k.T]) =
+      def at[E2](k: Witness)(implicit R: SurfaceGetterK[P, E2, E1, k.T]) =
         R.apply(r)
 
-      def at[K <: HList, E2](k: K)(implicit R: SurfaceGetterK[E2, E1, K]) =
+      def at[K <: HList, E2](k: K)(implicit R: SurfaceGetterK[P, E2, E1, K]) =
         R.apply(r)
     }
   }
@@ -23,14 +23,14 @@ object SurfaceGetterK extends SurfaceGetterKImplicits{
 
 trait SurfaceGetterKImplicits extends SurfaceGetterKImplicitsLPI{
 
-  def apply[E1, E2, K](implicit R: SurfaceGetterK[E1, E2, K]) = R
+  def apply[P[_], E1, E2, K](implicit R: SurfaceGetterK[P, E1, E2, K]) = R
 
   implicit def surfaceGetterK_singleField[
-      E2, E1, K, LE2 <: HList](implicit
+      P[_], E2, E1, K, LE2 <: HList](implicit
       GE2: LabelledGeneric.Aux[E2, LE2],
       S: Selector.Aux[LE2, K, E1]) =
-    new SurfaceGetterK[E2, E1, K]{
-      def apply[P[_]] = λ[Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]]{
+    new SurfaceGetterK[P, E2, E1, K]{
+      val apply = λ[Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]]{
         _.local((GE2.to _) andThen S.apply)
       }
     }
@@ -39,12 +39,12 @@ trait SurfaceGetterKImplicits extends SurfaceGetterKImplicitsLPI{
 trait SurfaceGetterKImplicitsLPI{
 
   implicit def surfaceGetterK_multipleField[
-      E2, E1, K <: HList, LE2 <: HList, LE1 <: HList](implicit
+      P[_], E2, E1, K <: HList, LE2 <: HList, LE1 <: HList](implicit
       GE2: LabelledGeneric.Aux[E2, LE2],
       GE1: Generic.Aux[E1, LE1],
       S: SelectAll.Aux[LE2, K, LE1]) =
-    new SurfaceGetterK[E2, E1, K]{
-      def apply[P[_]] = λ[Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]]{
+    new SurfaceGetterK[P, E2, E1, K]{
+      val apply = λ[Kleisli[P, E1, ?] ~> Kleisli[P, E2, ?]]{
         _.local((GE2.to _) andThen S.apply andThen GE1.from)
       }
     }

--- a/src/main/scala/SurfaceLens.scala
+++ b/src/main/scala/SurfaceLens.scala
@@ -1,0 +1,61 @@
+package shapelens
+
+import cats._, cats.data._, cats.implicits._
+
+import shapeless._, ops.hlist._
+import util.SetAll
+
+trait SurfaceLens[P[_], E2, E1]{
+  val apply: StateT[P, E1, ?] ~> StateT[P, E2, ?]
+}
+
+object SurfaceLens extends SurfaceLensImplicits{
+
+  trait Syntax{
+    implicit def stateView[P[_], E2, E1, T](
+        r: StateT[P, E1, T])(implicit
+        S: SurfaceLens[P, E2, E1]): StateT[P, E2, T] =
+      S.apply(r)
+  }
+}
+
+trait SurfaceLensImplicits extends SurfaceLensLPI{
+
+  def apply[P[_], E2, E1](implicit S: SurfaceLens[P, E2, E1]) = S
+
+  implicit def surfaceLens_singleField[
+      P[_]: Monad, E2, E1, LE2 <: HList](implicit
+      GE2: Generic.Aux[E2, LE2],
+      Mod: Modifier.Aux[LE2, E1, E1, (E1, LE2)]) = new SurfaceLens[P, E2, E1]{
+    val apply = new (StateT[P, E1,?] ~> StateT[P, E2,?]){
+      def apply[T](stateE1: StateT[P, E1, T]) = StateT{ e2 =>
+        val (get, _) = Mod(GE2.to(e2), identity[E1])
+        stateE1.run(get) map {
+          case (ne1, out) =>
+            val (_, set) = Mod(GE2.to(e2), _ => ne1)
+            (GE2.from(set), out)
+        }
+      }
+    }
+  }
+}
+
+trait SurfaceLensLPI{
+
+  implicit def surfaceLens_multipleField[
+      P[_]: Monad, E2, E1, LE2 <: HList, LE1 <: HList](implicit
+      GE2: Generic.Aux[E2, LE2],
+      GE1: Generic.Aux[E1, LE1],
+      Get: SelectAll[LE2, LE1],
+      Set: SetAll[LE2, LE1]) = new SurfaceLens[P, E2, E1]{
+    val apply = new (StateT[P, E1,?] ~> StateT[P, E2,?]){
+      def apply[T](stateE1: StateT[P, E1, T]) = StateT{ e2 =>
+        stateE1.run(GE1.from(Get(GE2.to(e2)))) map {
+          case (e1, out) =>
+            (GE2.from(Set(GE2.to(e2), GE1.to(e1))), out)
+        }
+      }
+    }
+  }
+}
+

--- a/src/main/scala/monocle/Getter.scala
+++ b/src/main/scala/monocle/Getter.scala
@@ -9,8 +9,8 @@ object Getter{
   def apply[E2, E1](implicit G: MGetter[E2, E1]) = G
 
   trait Implicits{
-    implicit def monocleGetter[E2, E1](implicit
-      S: SurfaceGetter[E2, E1]): MGetter[E2, E1] =
-      MGetter(S[Id](Kleisli.ask).apply)
+    implicit def monocleGetter[P[_], E2, E1](implicit
+      S: SurfaceGetter[Id, E2, E1]): MGetter[E2, E1] =
+      MGetter(S.apply(Kleisli.ask).apply)
   }
 }

--- a/src/main/scala/monocle/Getter.scala
+++ b/src/main/scala/monocle/Getter.scala
@@ -1,0 +1,16 @@
+package shapelens
+package monocle
+
+import _root_.monocle.{Getter => MGetter}
+import cats.Id, cats.data.Kleisli
+
+object Getter{
+
+  def apply[E2, E1](implicit G: MGetter[E2, E1]) = G
+
+  trait Implicits{
+    implicit def monocleGetter[E2, E1](implicit
+      S: SurfaceGetter[E2, E1]): MGetter[E2, E1] =
+      MGetter(S[Id](Kleisli.ask).apply)
+  }
+}

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,4 +1,5 @@
 package object shapelens
   extends SurfaceGetter.Syntax
   with SurfaceGetterK.Syntax
+  with SurfaceLens.Syntax
   with shapelens.monocle.Getter.Implicits

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,0 +1,4 @@
+package object shapelens
+  extends SurfaceGetter.Syntax
+  with SurfaceGetterK.Syntax
+  with shapelens.monocle.Getter.Implicits

--- a/src/main/scala/util/SetAll.scala
+++ b/src/main/scala/util/SetAll.scala
@@ -1,0 +1,47 @@
+package shapelens
+package util
+
+import shapeless._
+import shapeless.ops.hlist.Modifier
+
+trait SetAll[L, S] extends DepFn2[L, S] with Serializable {
+  type Out = L
+}
+
+object SetAll extends SetAllLPI{
+
+  def apply[L, S](implicit P: SetAll[L, S]): SetAll[L, S] = P
+
+  implicit def hnilSetAll[L <: HList]: SetAll[L, HNil] =
+    new SetAll[L, HNil] {
+      def apply(l: L, nil: HNil): L = l
+    }
+
+  implicit def hconsSetAll[L <: HList, H, S <: HList](implicit
+      M: Modifier.Aux[L, H, H, (H,L)],
+      P: SetAll[L, S]): SetAll[L, H :: S] =
+    new SetAll[L, H :: S] {
+      def apply(l: L, hs: H :: S): L =
+        M(P(l, hs.tail), _ => hs.head)._2
+    }
+
+  implicit def genericSingleSetAll[P1, P2, L1 <: HList](implicit
+      G1: Generic.Aux[P1, L1],
+      SA: Lazy[SetAll[L1, P2 :: HNil]]): SetAll[P1, P2] =
+    new SetAll[P1, P2]{
+      def apply(p1: P1, p2: P2): P1 =
+        G1.from(SA.value(G1.to(p1), p2 :: HNil))
+    }
+}
+
+trait SetAllLPI{
+
+  implicit def genericSetAll[P1, P2, L1 <: HList, L2 <: HList](implicit
+      G1: Generic.Aux[P1, L1],
+      G2: Generic.Aux[P2, L2],
+      SA: Lazy[SetAll[L1, L2]]): SetAll[P1, P2] =
+    new SetAll[P1, P2]{
+      def apply(p1: P1, p2: P2): P1 =
+        G1.from(SA.value(G1.to(p1), G2.to(p2)))
+    }
+}

--- a/src/test/scala/DeepLens.scala
+++ b/src/test/scala/DeepLens.scala
@@ -1,10 +1,10 @@
-package org.hablapps.shapelens
+package shapelens
 package test
 
 import org.scalatest._
 import shapeless._
 
-class UniversitySpec extends FlatSpec with Matchers {
+class DeepLensSpec extends FlatSpec with Matchers {
 
   case class City(population: Int, name: String, university: University)
   case class University(name: String, math: Department)
@@ -16,21 +16,21 @@ class UniversitySpec extends FlatSpec with Matchers {
   val mostoles = City(200000, "mostoles", urjc)
   val leganes  = City(150000, "leganes",  uc3m)
 
-  "Shapelens" should "generate a lens for a particular field" in {
-    val population = Shapelens[City, population :: HNil]
+  "DeepLens" should "generate a lens for a particular field" in {
+    val population = DeepLens[City, population :: HNil]
     population.get(mostoles) shouldBe 200000
     population.modify(_ * 2)(mostoles) shouldBe mostoles.copy(population = 400000)
   }
 
   it should "generate a lens for a nested field" in {
-    val budget = Shapelens[University, math :: budget :: HNil]
+    val budget = DeepLens[University, math :: budget :: HNil]
     budget.get(urjc) shouldBe math.budget
     budget.set(0)(urjc) shouldBe urjc.copy(math = Department(0))
   }
 
   it should "disambiguate conflicts using path" in {
-    val cityName = Shapelens[City, name :: HNil]
-    val univName = Shapelens[City, university :: name :: HNil]
+    val cityName = DeepLens[City, name :: HNil]
+    val univName = DeepLens[City, university :: name :: HNil]
     cityName.get(mostoles) shouldBe mostoles.name
     univName.get(mostoles) shouldBe mostoles.university.name
   }

--- a/src/test/scala/DeepLens.scala
+++ b/src/test/scala/DeepLens.scala
@@ -36,12 +36,12 @@ class DeepLensSpec extends FlatSpec with Matchers {
   }
 
   it should "generate the identity lens" in {
-    val city = Shapelens[City, HNil]
+    val city = DeepLens[City, HNil]
     city.get(mostoles) shouldBe mostoles
     city.set(leganes)(mostoles) shouldBe leganes
   }
 
-  "Shapelens[City, budget :: HNil]" shouldNot compile
+  "DeepLens[City, budget :: HNil]" shouldNot compile
 
   // XXX: is it possible to integrate `LabelledGeneric` with literal types? If
   // so, we could avoid these aliases and use `'population` directly!

--- a/src/test/scala/SurfaceGetter.scala
+++ b/src/test/scala/SurfaceGetter.scala
@@ -1,0 +1,106 @@
+package shapelens
+package test
+
+import cats.data.{Kleisli, Reader}
+
+import shapeless._
+
+import org.scalatest._
+
+class SurfaceGetterSpec extends FunSpec with Matchers {
+
+  describe("Getter extractor from type info"){
+
+    describe("When there is no ambiguity"){
+
+      it("should work for single fields"){
+        Reader[Int,Unit](_ => ()):
+          Reader[(Int, String, Boolean), Unit]
+
+        Reader[String, Unit](_ => ()):
+          Reader[(Int, String, Boolean), Unit]
+
+        Reader[Boolean, Unit](_ => ()):
+          Reader[(Int, String, Boolean), Unit]
+        }
+
+      it("should work for two consecutive fields"){
+        Reader[(Int,String), Unit](_ => ()):
+          Reader[(Int, String, Boolean), Unit]
+
+        Reader[(String, Boolean), Unit](_ => ()):
+          Reader[(Int, String, Boolean), Unit]
+
+        Reader[(Int, Boolean), Unit](_ => ()):
+          Reader[(Int, String, Boolean), Unit]
+        }
+
+      it("should work for non-consecutive fields"){
+        Reader[(Int,Boolean), Unit](_ => ()):
+          Reader[(Int, String, Boolean, Char), Unit]
+
+        Reader[(Int,Char), Unit](_ => ()):
+          Reader[(Int, String, Boolean, Char), Unit]
+
+        Reader[(String,Char), Unit](_ => ()):
+          Reader[(Int, String, Boolean, Char), Unit]
+        }
+
+      it("should work for reverse fields"){
+        Reader[(Boolean, Int), Unit](_ => ()):
+          Reader[(Int, String, Boolean, Char), Unit]
+
+        Reader[(Char, Int), Unit](_ => ()):
+          Reader[(Int, String, Boolean, Char), Unit]
+
+        Reader[(String,Int), Unit](_ => ()):
+          Reader[(Int, String, Boolean, Char), Unit]
+        }
+    }
+
+    describe("In ambigous settings"){
+      it("should work for the first matching (single fields)"){
+        val r: Reader[(Int, Int), Int] =
+          Kleisli.ask[Id, Int]
+
+        r((1,2)) shouldBe 1
+      }
+
+      it("should work for the first matching (multiple fields)"){
+        val r: Reader[(Int, String, Int, String), (Int, String)] =
+          Kleisli.ask[Id, (Int, String)]
+
+        r((1, "a", 2, "b")) shouldBe ((1,"a"))
+      }
+    }
+
+    describe("When both single and multiple fields match"){
+
+      it("should have precedence the single field selector"){
+        val r1: Reader[((Int, String), Int, String), (Int, String)] =
+          Kleisli.ask[Id, (Int, String)]
+
+        r1(((1,"a"),2,"b")) shouldBe ((1,"a"))
+
+        val r2: Reader[(Int, String, (Int, String)), (Int, String)] =
+          Kleisli.ask[Id, (Int, String)]
+
+        r2((2, "b", (1,"a"))) shouldBe ((1,"a"))
+      }
+    }
+
+    describe("When there is no possible selector"){
+
+      it("shouldn't work for non-existing fields"){
+        """val r: Reader[(Int, String), Unit] =
+             Reader[Boolean, Unit](_ => ())""" shouldNot compile
+      }
+
+      it("shouldn't work for nested existing fields"){
+        """val r: Reader[((Boolean, Int), String), Unit] =
+             Reader[Boolean, Unit](_ => ())""" shouldNot compile
+      }
+    }
+  }
+}
+

--- a/src/test/scala/SurfaceGetterK.scala
+++ b/src/test/scala/SurfaceGetterK.scala
@@ -1,0 +1,51 @@
+package shapelens
+package test
+
+import cats.~>, cats.data.Reader
+
+import shapeless._, record._
+import shapeless.syntax.singleton._
+
+import org.scalatest._
+
+class SurfaceGetterKSpec extends FunSpec with Matchers {
+
+  describe("Getter for particular fields"){
+
+    val rI: Reader[Int, Unit] =
+      Reader{ _ => () }
+
+    val rIS: Reader[(Int, String), Unit] =
+      Reader{ _ => () }
+
+    it("should work without syntax"){
+      SurfaceGetterK[
+        (Boolean, Int, String, Char),
+        (Int, String),
+        Witness.`'_2`.T :: Witness.`'_3`.T :: HNil
+      ].apply(rIS):
+        Reader[(Boolean, Int, String, Char), Unit]
+    }
+
+    it("should work with syntax"){
+      (rIS at '_2.narrow :: '_3.narrow :: HNil):
+        Reader[(Boolean, Int, String, Char), Unit]
+    }
+
+    it("should work for single selections"){
+
+      SurfaceGetterK[
+        (Boolean, Int, String, Char),
+        Int,
+        Witness.`'_2`.T
+      ].apply(rI):
+        Reader[(Boolean, Int, String, Char), Unit]
+
+      val rBISC_2: Reader[(Boolean, Int, String, Char), Int] =
+        Reader[Int, Int](identity) at '_2
+
+      rBISC_2((true, 1, "", 'a')) shouldBe 1
+    }
+  }
+}
+

--- a/src/test/scala/SurfaceGetterK.scala
+++ b/src/test/scala/SurfaceGetterK.scala
@@ -1,7 +1,7 @@
 package shapelens
 package test
 
-import cats.~>, cats.data.Reader
+import cats.{Id, ~>}, cats.data.{Kleisli, Reader}
 
 import shapeless._, record._
 import shapeless.syntax.singleton._
@@ -19,7 +19,7 @@ class SurfaceGetterKSpec extends FunSpec with Matchers {
       Reader{ _ => () }
 
     it("should work without syntax"){
-      SurfaceGetterK[
+      SurfaceGetterK[Id,
         (Boolean, Int, String, Char),
         (Int, String),
         Witness.`'_2`.T :: Witness.`'_3`.T :: HNil
@@ -34,7 +34,7 @@ class SurfaceGetterKSpec extends FunSpec with Matchers {
 
     it("should work for single selections"){
 
-      SurfaceGetterK[
+      SurfaceGetterK[Id,
         (Boolean, Int, String, Char),
         Int,
         Witness.`'_2`.T
@@ -42,7 +42,9 @@ class SurfaceGetterKSpec extends FunSpec with Matchers {
         Reader[(Boolean, Int, String, Char), Unit]
 
       val rBISC_2: Reader[(Boolean, Int, String, Char), Int] =
-        Reader[Int, Int](identity) at '_2
+        Reader[Int, Int](identity).at[(Boolean, Int, String, Char)]('_2)(
+          SurfaceGetterK[Id,(Boolean, Int, String, Char),Int,Witness.`'_2`.T])
+            // TBD: why is this parameter not found implicitly?
 
       rBISC_2((true, 1, "", 'a')) shouldBe 1
     }

--- a/src/test/scala/SurfaceLens.scala
+++ b/src/test/scala/SurfaceLens.scala
@@ -1,0 +1,52 @@
+package shapelens
+package test
+
+import cats.data.State, cats.{Id, Eval}
+import org.scalatest._
+
+class SurfaceLens extends FunSpec with Matchers{
+
+  describe("Surface lenses"){
+
+    it("should be obtained implicitly"){
+      SurfaceLens[Id, (Int, String), Int]
+      SurfaceLens[Id, (Int, String), String]
+      SurfaceLens[Id, (Int, String, Boolean), (Int, String)]
+      SurfaceLens[Id, (Int, String, Boolean), (Boolean, String)]
+      SurfaceLens[Id, ((Boolean, String), String, Boolean), (Boolean, String)]
+    }
+
+    it("should work for single fields"){
+      SurfaceLens[Eval, (Int, String), Int].apply
+        .apply(State.get[Int])
+        .runA((1,""))
+        .value shouldBe 1
+    }
+
+    it("should work for multiple fields"){
+      SurfaceLens[Eval, (Int, String, Boolean), (Int, String)].apply
+        .apply(State.get[(Int, String)])
+        .runA((1, "", false))
+        .value shouldBe ((1, ""))
+    }
+
+    it("should give preference to single fields"){
+      SurfaceLens[Eval, ((Boolean, String), String, Boolean), (Boolean, String)].apply
+        .apply(State.get[(Boolean, String)])
+        .runA(((false, ""), "a", true))
+        .value shouldBe ((false, ""))
+    }
+
+    it("should allow us to lift state computations"){
+
+      State.get[(Boolean, String)]:
+        State[(Boolean, String), (Boolean, String)]
+
+      State.get[(Boolean, String)]:
+        State[(Boolean, String, Int), (Boolean, String)]
+
+      State.get[(String, Boolean)]:
+        State[(Boolean, String, Int), (String, Boolean)]
+    }
+  }
+}

--- a/src/test/scala/monocle/MonocleGetter.scala
+++ b/src/test/scala/monocle/MonocleGetter.scala
@@ -1,0 +1,46 @@
+package shapelens
+package monocle
+package test
+
+import org.scalatest._
+
+class MonocleGetterSpec extends FunSpec with Matchers {
+
+  describe("Monocle's Getter"){
+
+    it("should be obtained for single fields"){
+      Getter[(Int, String, Boolean), Int].get((1,"",true)) shouldBe 1
+
+      Getter[(Int, String, Boolean), String].get((1,"",true)) shouldBe ""
+
+      Getter[(Int, String, Boolean), Boolean].get((1,"",true)) shouldBe true
+    }
+
+    it("should be obtained for multiple fields"){
+      Getter[(Int, String, Boolean), (Int, String)].get((1,"",true)) shouldBe ((1, ""))
+
+      Getter[(Int, String, Boolean), (String, Int)].get((1,"",true)) shouldBe (("", 1))
+
+      Getter[(Int, String, Boolean), (Int, Boolean)].get((1,"",true)) shouldBe ((1, true))
+    }
+
+    it("should be obtained for arbitrary products, not just tuples"){
+      case class IS(i: Int, s: String)
+      case class SI(s: String, i: Int)
+      case class IB(i: Int, b: Boolean)
+
+      Getter[(Int, String, Boolean), IS].get((1,"",true)) shouldBe IS(1, "")
+
+      Getter[(Int, String, Boolean), SI].get((1,"",true)) shouldBe SI("", 1)
+
+      Getter[(Int, String, Boolean), IB].get((1,"",true)) shouldBe IB(1, true)
+    }
+
+    it("shouldn't be obtained if no surface view is available"){
+      """Getter[(Int, String, Boolean), Char]""" shouldNot compile
+
+      """Getter[((Int, Char), String, Boolean), Char]""" shouldNot compile
+    }
+  }
+}
+

--- a/src/test/scala/util/SetAll.scala
+++ b/src/test/scala/util/SetAll.scala
@@ -1,0 +1,37 @@
+package shapelens
+package util
+package test
+
+import shapeless._
+
+import org.scalatest._
+
+class SetAllSpec extends FunSpec with Matchers{
+
+  describe("SetAll"){
+
+    it("should find evidences for HLists"){
+      SetAll[HNil, HNil]
+      SetAll[Int::String::HNil, Int::HNil]
+      SetAll[Int::String::HNil, Int::String::HNil]
+    }
+
+    it("should find evidences for Generics"){
+      SetAll[(Int, String), Int]
+      SetAll[(Int, String, Boolean), (Int, String)]
+    }
+
+    it("should work for single fields"){
+      SetAll[(Int, String), Int].apply((1,""), 2) shouldBe
+        ((2, ""))
+
+      SetAll[(Int, String), String].apply((1,""), "hola") shouldBe
+        ((1, "hola"))
+    }
+
+    it("should work for multiple fields"){
+      SetAll[(Int, String, Boolean), (Int, Boolean)].apply((1,"",false), (2,true)) shouldBe
+        ((2, "", true))
+    }
+  }
+}


### PR DESCRIPTION
This PR provides a number of natural transformations useful for instantiating type classes in any MTL-based application.

We have natural transformations for lifting 1) reader monads into reader monads, 2) state monads into state monads, and, 3), reader monads into state monads. 

The third transformation should be derived modularly, in terms of more general transformations (hoist for StateT or ReaderT).

Naming should also be discussed (but implemented in forthcoming PRs): e.g. `SurfaceGetter` => `SurfaceKleisliToKleisli`, etc. This would correspond more closely to the `KleisliToSTateT` transformation.

Also, we should evaluate the possibility of extending the `NatTrans` type class by the particular types of transformations, instead of deriving implicit instances for each of them.

Monocle abstractions (just `Getter`, although the same should be done for obtaining a surface monocle `Lens`) has been packaged into the `monocle` package. 

Added support for cross compilation to 2.10.

The project is now published in sonatype. Instructions can be found [here](https://hablapps.atlassian.net/browse/SPEECH-215)